### PR TITLE
Include generated files, and rate limiter

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,0 @@
-language: java
-
-jdk:
-  - oraclejdk8
-  - oraclejdk7
-  - openjdk7
-  - openjdk6

--- a/README.md
+++ b/README.md
@@ -1,4 +1,3 @@
-[![Build Status](https://travis-ci.org/PRIDE-Archive/web-service.svg)](https://travis-ci.org/PRIDE-Archive/web-service)
 # web-service
 PRIDE Archive web service
  

--- a/pom.xml
+++ b/pom.xml
@@ -19,6 +19,7 @@
          These are:
                 pride-archive-solr-cores (provide the SOLR cores for the searches)
                 pride-archive-user-service (for security related configuration)
+                redis-production (for Redis connections)
 
           If DB connections are provided via JNDI no other profiles are needed, otherwise:
                 db-pride-repo-pridepro (database connection config)
@@ -123,6 +124,11 @@
     </build>
 
     <dependencies>
+        <dependency>
+            <groupId>redis.clients</groupId>
+            <artifactId>jedis</artifactId>
+            <version>2.9.0</version>
+        </dependency>
         <!-- overwrite older versions, as there is a bug with sorting in paged results -->
         <dependency>
             <groupId>org.apache.solr</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>uk.ac.ebi.pride.maven</groupId>
         <artifactId>pride-base-master</artifactId>
-        <version>1.0.3</version>
+        <version>1.0.5</version>
     </parent>
 
     <groupId>uk.ac.ebi.pride.archive</groupId>
@@ -29,19 +29,11 @@
                 To run locally, for example with jetty, a local server configuration is needed.
      -->
 
-    <!--scm git config-->
-    <scm>
-        <connection>scm:git:github.com/PRIDE-Archive/web-service.git</connection>
-        <developerConnection>scm:git:git@github.com:PRIDE-Archive/web-service.git</developerConnection>
-        <url>https://github.com/PRIDE-Archive/web-service.git</url>
-        <tag>HEAD</tag>
-    </scm>
-
     <properties>
-        <archive.ws.model.version>0.2.12</archive.ws.model.version>
+        <archive.ws.model.version>0.2.13</archive.ws.model.version>
         <archive.security.version>0.1.2</archive.security.version>
-        <archive.search.version>1.0.3</archive.search.version>
-        <archive.utils.version>0.1.10</archive.utils.version>
+        <archive.search.version>1.0.8</archive.search.version>
+        <archive.utils.version>0.1.21</archive.utils.version>
         <pride.web.utils.version>1.3.10</pride.web.utils.version>
         <solr.solrj.version>4.2.0</solr.solrj.version>
         <swagger.version>0.8.6</swagger.version>
@@ -257,10 +249,12 @@
         <dependency>
             <groupId>commons-httpclient</groupId>
             <artifactId>commons-httpclient</artifactId>
+            <version>3.1</version>
         </dependency>
         <dependency>
             <groupId>commons-fileupload</groupId>
             <artifactId>commons-fileupload</artifactId>
+            <version>1.3.1</version>
         </dependency>
 
         <!-- REST documentation (Swagger) -->
@@ -287,22 +281,25 @@
             <groupId>org.mockito</groupId>
             <artifactId>mockito-core</artifactId>
         </dependency>
-
-
     </dependencies>
 
     <repositories>
-        <!-- EBI repo -->
         <repository>
-            <id>nexus-ebi-repo</id>
-            <name>The EBI internal repository</name>
-            <url>http://www.ebi.ac.uk/intact/maven/nexus/content/repositories/ebi-repo/</url>
-            <releases>
-            </releases>
-            <snapshots>
-                <enabled>false</enabled>
-            </snapshots>
+            <id>nexus-ebi-release-repo</id>
+            <url>http://www.ebi.ac.uk/Tools/maven/repos/content/groups/ebi-repo/</url>
+        </repository>
+        <repository>
+            <id>nexus-ebi-snapshot-repo</id>
+            <url>http://www.ebi.ac.uk/Tools/maven/repos/content/groups/ebi-snapshots/</url>
         </repository>
     </repositories>
+
+    <!--scm git config-->
+    <scm>
+        <connection>scm:git:https://github.com/PRIDE-Archive/web-service.git</connection>
+        <developerConnection>scm:git:https://github.com/PRIDE-Archive/web-service.gi</developerConnection>
+        <url>https://github.com/PRIDE-Archive/web-service.git</url>
+        <tag>HEAD</tag>
+    </scm>
 
 </project>

--- a/src/main/java/uk/ac/ebi/pride/archive/web/service/interceptor/RateLimitInterceptor.java
+++ b/src/main/java/uk/ac/ebi/pride/archive/web/service/interceptor/RateLimitInterceptor.java
@@ -1,0 +1,68 @@
+package uk.ac.ebi.pride.archive.web.service.interceptor;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Service;
+import org.springframework.web.servlet.handler.HandlerInterceptorAdapter;
+import redis.clients.jedis.JedisPool;
+import redis.clients.jedis.JedisPoolConfig;
+
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+
+import static uk.ac.ebi.pride.archive.web.service.interceptor.RateLimitServiceImpl.COUNT_EXPIRY_PERIOD_SECONDS;
+
+/**
+ * This class rate limits all Web Service GET requests. This is according to the values set for
+ * MAX_REQUESTS_PER_PERIOD which is double the value set for RateLimitServiceImpl.COUNT_EXPIRY_PERIOD_SECONDS.
+ * The purpose is to limit the frequency individual users may query for information, primarily in relation
+ * to PSMs. Pagination alone does not solve such a problem.
+ *
+ * @author Tobias Ternent
+ */
+@Service
+public class RateLimitInterceptor extends HandlerInterceptorAdapter {
+  private static final Logger logger = LoggerFactory.getLogger(RateLimitInterceptor.class);
+
+  private static final int MAX_REQUESTS_PER_PERIOD = COUNT_EXPIRY_PERIOD_SECONDS * 2;
+  @Value("#{redisConfig['redis.host']}")
+  private String redisServer;
+  @Value("#{redisConfig['redis.port']}")
+  private String redisPort;
+  @Value("#{redisConfig['redis.password']}")
+  private String redisPassword;
+  private JedisPool jedisPool;
+
+  @Autowired
+  private RateLimitService rateLimitService;
+
+  /**
+   * This method is called before handling every single request.
+   * @param request the request sent to the Web Service.
+   * @param response the response sent back to the user.
+   * @param handler the handler object.
+   * @return true to process the request onwards as normal, false otherwise and the request is not processed at all.
+   * @throws Exception Any exception encountered attempting to limit the user's requests.
+   */
+  public boolean preHandle(HttpServletRequest request,
+                           HttpServletResponse response, Object handler) throws Exception {
+    boolean result = true;
+    if (jedisPool==null) {
+      jedisPool = new JedisPool(new JedisPoolConfig(), redisServer, Integer.parseInt(redisPort), 0, redisPassword);
+    }
+    if ("GET".equalsIgnoreCase(request.getMethod())) {
+      int incrementUserGetCount = rateLimitService.incrementLimit("GET~" + request.getRemoteAddr(), jedisPool);
+      logger.debug("Current count for user: " + request.getRemoteAddr() + " is: " + incrementUserGetCount);
+      if (incrementUserGetCount >= MAX_REQUESTS_PER_PERIOD) {
+        response.sendError(429, "Rate limit exceeded (" + MAX_REQUESTS_PER_PERIOD + "), please wait " + COUNT_EXPIRY_PERIOD_SECONDS + " seconds.");
+        result = false;
+        logger.info("Throttled connections for user: " + request.getRemoteAddr());
+      } else {
+        response.addIntHeader("Remaining request count", MAX_REQUESTS_PER_PERIOD - incrementUserGetCount);
+      }
+    }
+    return result;
+  }
+}

--- a/src/main/java/uk/ac/ebi/pride/archive/web/service/interceptor/RateLimitService.java
+++ b/src/main/java/uk/ac/ebi/pride/archive/web/service/interceptor/RateLimitService.java
@@ -1,0 +1,12 @@
+package uk.ac.ebi.pride.archive.web.service.interceptor;
+
+import redis.clients.jedis.JedisPool;
+
+/** This defines the interface for limiing the rate of users' requests.
+ *
+ * @author Tobias Ternent
+ */
+public interface RateLimitService {
+
+  public int incrementLimit(String userKey, JedisPool jedisPool);
+}

--- a/src/main/java/uk/ac/ebi/pride/archive/web/service/interceptor/RateLimitServiceImpl.java
+++ b/src/main/java/uk/ac/ebi/pride/archive/web/service/interceptor/RateLimitServiceImpl.java
@@ -1,0 +1,48 @@
+package uk.ac.ebi.pride.archive.web.service.interceptor;
+
+import org.springframework.context.support.GenericApplicationContext;
+import org.springframework.scheduling.annotation.EnableScheduling;
+import org.springframework.stereotype.Service;
+import redis.clients.jedis.Jedis;
+import redis.clients.jedis.JedisPool;
+
+/**
+ * This class implements the RateLimitService interface to limit users' connections.
+ * Redis is used as a key/value store. The key is made up of a user's IP plus general request type (i.e. GET),
+ * and the value is the current count for the number of requests made in the time period COUNT_EXPIRY_PERIOD_SECONDS.
+ * In Redis, Key/value pairs expire after COUNT_EXPIRY_PERIOD_SECONDS from the last increment or initial insert.
+ *
+ * @author Tobias Ternent
+ */
+@Service
+@EnableScheduling
+public class RateLimitServiceImpl extends GenericApplicationContext implements RateLimitService {
+  static final int COUNT_EXPIRY_PERIOD_SECONDS = 30;
+
+  /**
+   * This method connects to Redis to track the count of users' total requests within the defined time period.
+   * @param userKey the key to use for the user.
+   * @param jedisPool the pool for new Redis connections.
+   * @return the user's current count of requests within the latest time period.
+   */
+  @Override
+  public int incrementLimit(String userKey, JedisPool jedisPool) {
+    int result;
+    Jedis jedis = jedisPool.getResource();
+    try {
+      if (jedis.exists(userKey)) {
+        jedis.incr(userKey);
+        result = Integer.parseInt(jedis.get(userKey));
+      } else {
+        jedis.set(userKey, "1");
+        result = 1;
+      }
+      jedis.expire(userKey, COUNT_EXPIRY_PERIOD_SECONDS);
+    } finally {
+      if (jedis != null) {
+        jedis.close();
+      }
+    }
+    return result;
+  }
+}

--- a/src/main/java/uk/ac/ebi/pride/archive/web/service/util/ObjectMapper.java
+++ b/src/main/java/uk/ac/ebi/pride/archive/web/service/util/ObjectMapper.java
@@ -321,15 +321,9 @@ public final class ObjectMapper {
 
         List<FileDetail> mappedObjects = new ArrayList<FileDetail>(fileSummaries.size());
         for (FileSummary fileSummary : fileSummaries) {
-            if (fileSummary.getFileSource() == ProjectFileSource.INTERNAL) {
-                // we skip internal files
-                continue;
-            }
-            if (fileSummary.getFileSource() == ProjectFileSource.GENERATED) {
-                // for now also skip generated files, until we decide to make them public
-                continue;
-            }
-            mappedObjects.add( mapFileSummaryToWSFileDetail(fileSummary) );
+            if (fileSummary.getFileSource() != ProjectFileSource.INTERNAL) {
+                mappedObjects.add( mapFileSummaryToWSFileDetail(fileSummary) );
+            } // skip internal files
         }
         return mappedObjects;
     }

--- a/src/main/resources/META-INF/props/redis.properties
+++ b/src/main/resources/META-INF/props/redis.properties
@@ -1,0 +1,3 @@
+redis.host = ${redis.server.host}
+redis.port = ${redis.server.port}
+redis.password = ${redis.server.password}

--- a/src/main/resources/META-INF/spring/app-context-bootstrap.xml
+++ b/src/main/resources/META-INF/spring/app-context-bootstrap.xml
@@ -29,6 +29,8 @@
 
     <util:properties id="databaseConfig" location="classpath:META-INF/props/db.properties"/>
 
+    <util:properties id="redisConfig" location="classpath:META-INF/props/redis.properties"/>
+
     <bean id="userWebServiceUrl" class="uk.ac.ebi.pride.archive.repo.user.service.url.UserWebServiceUrl">
         <constructor-arg name="signUpUrl" value="${user.signup.url}"/>
         <constructor-arg name="passwordResetUrl" value="${user.reset.password.url}"/>

--- a/src/main/webapp/WEB-INF/spring/mvc-config.xml
+++ b/src/main/webapp/WEB-INF/spring/mvc-config.xml
@@ -11,6 +11,13 @@
 
     <!-- Enables the Spring MVC @Controller programming model -->
     <annotation-driven/>
+    <interceptors>
+        <interceptor>
+            <mapping path="/**"/>
+            <beans:bean class="uk.ac.ebi.pride.archive.web.service.interceptor.RateLimitInterceptor">
+            </beans:bean>
+        </interceptor>
+    </interceptors>
 
     <context:component-scan base-package="uk.ac.ebi.pride.archive.web.service"/>
 


### PR DESCRIPTION
# Balance changes
## Buffs
- When available, PRIDE-generated files (mztab, mgf) are now included when a request is made for a project's files.
## Nerfs
- Users' GET requests are now limited to a rate of 60 requests per 30 second period.
- TravisCI can never pass, it has been completely removed.